### PR TITLE
Improve extract inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,20 @@ VITE_COGNITO_APP_CLIENT_ID=<your_app_client_id> # terraform output cognito_app_c
 VITE_API_URL=<backend_api_url>                  # or terraform output http_api_endpoint
 ```
 
+### Extraction API
+
+Send a `POST` request to `/extract` with the following JSON body:
+
+```json
+{
+  "appName": "My App",
+  "iosAppId": "123456789",
+  "androidAppId": "com.example.app",
+  "fromDate": "2024-01-01",
+  "toDate": "2024-01-31"
+}
+```
+
 ---
 
 ## 🔐 Authentication

--- a/backend/routes/extract.js
+++ b/backend/routes/extract.js
@@ -11,7 +11,7 @@ const ddb = new DynamoDBClient({ region: REGION });
 
 async function createExtraction(req, res) {
   try {
-    const { appName, fromDate, toDate } = req.body;
+    const { appName, iosAppId, androidAppId, fromDate, toDate } = req.body;
     const userId      = req.auth.sub;           // récupéré par express-jwt
     const extractionId = uuidv4();
     const nowISO      = new Date().toISOString();
@@ -23,6 +23,8 @@ async function createExtraction(req, res) {
         user_id:       { S: userId },
         extraction_id: { S: extractionId },
         app_name:      { S: appName },
+        ios_app_id:    { S: iosAppId },
+        android_app_id:{ S: androidAppId },
         from_date:     { S: fromDate },
         to_date:       { S: toDate },
         status:        { S: "pending" },
@@ -34,7 +36,15 @@ async function createExtraction(req, res) {
     // 2. Publier le message dans SQS
     await sqs.send(new SendMessageCommand({
       QueueUrl:    QUEUE_URL,
-      MessageBody: JSON.stringify({ userId, extractionId })
+      MessageBody: JSON.stringify({
+        userId,
+        extractionId,
+        appName,
+        iosAppId,
+        androidAppId,
+        fromDate,
+        toDate
+      })
     }));
 
     // 3. Répondre immédiatement avec l’ID


### PR DESCRIPTION
## Summary
- allow `extract` route to accept appName, iosAppId, androidAppId, fromDate and toDate
- store and forward those fields to SQS
- document `/extract` API in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686e46c538908333b43b2c855f3af243