### PR TITLE
Add extraction status route and page

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -11,7 +11,7 @@ const cors    = require("cors");
 const decodeJwtSub = require("./auth");
 
 // Import de la logique d’extraction
-const { createExtraction } = require("./routes/extract");
+const { createExtraction, getExtractionStatus } = require("./routes/extract");
 
 const app = express();
 app.use(cors());
@@ -35,6 +35,14 @@ app.post("/extract", (req, res) => {
     return res.status(401).json({ error: "Unauthorized" });
   }
   createExtraction(req, res);
+});
+
+// Récupérer le statut d'une extraction
+app.get("/extract/:id", (req, res) => {
+  if (!req.auth?.sub) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+  getExtractionStatus(req, res);
 });
 
 // Pour le dev local uniquement

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.840.0",
         "@aws-sdk/client-sqs": "^3.840.0",
+        "@aws-sdk/util-dynamodb": "^3.840.0",
         "@vendia/serverless-express": "^4.12.6",
         "aws-serverless-express": "^3.4.0",
         "cors": "^2.8.5",
@@ -650,6 +651,21 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-dynamodb": {
+      "version": "3.840.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.840.0.tgz",
+      "integrity": "sha512-DmTgUojCV4eCd2HDkFtNwocWoGz1Q/YTbdx4wFlUksrcLdFhI8CKRe6WVGZK0lxceIbtFONuseByMFo8hs/EMQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-dynamodb": "^3.840.0"
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.840.0",
     "@aws-sdk/client-sqs": "^3.840.0",
+    "@aws-sdk/util-dynamodb": "^3.840.0",
     "@vendia/serverless-express": "^4.12.6",
     "aws-serverless-express": "^3.4.0",
     "cors": "^2.8.5",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,7 +17,8 @@
     "jwt-decode": "^4.0.0",
     "process": "^0.11.10",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "react-router-dom": "^6.22.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,6 +1,8 @@
 import { useState, useEffect } from "react";
+import { Routes, Route, useNavigate } from "react-router-dom";
 import SignUp from "./SignUp";
 import SignIn from "./SignIn";
+import ExtractionStatus from "./ExtractionStatus";
 import axios from "axios";
 import { jwtDecode } from "jwt-decode";
 import { Auth } from "aws-amplify";
@@ -15,6 +17,7 @@ export default function App() {
   const [fromDate, setFromDate] = useState("");
   const [toDate, setToDate] = useState("");
   const [extractStatus, setExtractStatus] = useState("");
+  const navigate = useNavigate();
 
   useEffect(() => {
     if (token) {
@@ -53,6 +56,7 @@ export default function App() {
         },
       );
       setExtractStatus(`ID extraction : ${res.data.extractionId}`);
+      navigate(`/extraction/${res.data.extractionId}`);
     } catch (err) {
       console.error('Erreur extraction:', err);
       setExtractStatus("Erreur lors du lancement de l'extraction");
@@ -78,7 +82,7 @@ export default function App() {
     );
   }
 
-  return (
+  const dashboard = (
     <div className="p-6">
       <h1 className="text-2xl font-bold">Revox Dashboard</h1>
 
@@ -139,5 +143,12 @@ export default function App() {
         Se déconnecter
       </button>
     </div>
+  );
+
+  return (
+    <Routes>
+      <Route path="/" element={dashboard} />
+      <Route path="/extraction/:id" element={<ExtractionStatus token={token} />} />
+    </Routes>
   );
 }

--- a/frontend/src/ExtractionStatus.jsx
+++ b/frontend/src/ExtractionStatus.jsx
@@ -1,0 +1,32 @@
+import { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import axios from "axios";
+
+export default function ExtractionStatus({ token }) {
+  const { id } = useParams();
+  const [status, setStatus] = useState("pending");
+
+  useEffect(() => {
+    async function fetchStatus() {
+      try {
+        const res = await axios.get(`${import.meta.env.VITE_API_URL}/extract/${id}`, {
+          headers: { Authorization: `Bearer ${token}` }
+        });
+        setStatus(res.data.status);
+      } catch (err) {
+        console.error("Erreur statut extraction:", err);
+      }
+    }
+    fetchStatus();
+    const interval = setInterval(fetchStatus, 5000);
+    return () => clearInterval(interval);
+  }, [id, token]);
+
+  return (
+    <div className="p-6">
+      <h2 className="text-xl font-bold mb-4">Statut de l'extraction</h2>
+      <p className="mb-2">ID : {id}</p>
+      <p>Status : {status}</p>
+    </div>
+  );
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,6 +1,7 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App.jsx';
+import { BrowserRouter } from 'react-router-dom';
 import Amplify from 'aws-amplify';
 import awsConfig from './aws-exports';
 import { Buffer } from 'buffer';
@@ -10,6 +11,8 @@ Amplify.configure(awsConfig);
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </StrictMode>
 );


### PR DESCRIPTION
## Summary
- expose `GET /extract/:id` route in Express
- fetch extraction status from DynamoDB
- show new React page polling extraction status
- integrate React Router
- update dependencies

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` in backend *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686e6779ac348333809771d4345f2bcd