### PR TITLE
Fix 500 on GET /follow-app when user has no followed apps

### DIFF
--- a/backend/followApp.js
+++ b/backend/followApp.js
@@ -413,6 +413,7 @@ export async function getFollowedApps(req, res) {
     const dedup = (arr) => Array.from(new Set(Array.isArray(arr) ? arr : []));
 
     const follows = items.filter(it => it.app_pk && it.app_pk !== "APP_LINKS");
+    if (!follows.length) return res.status(200).json({ followed: [] });
 
     const seenMap = new Map(follows.map(it => [it.app_pk, {
       last_seen_total: Number.isFinite(it.last_seen_total) ? it.last_seen_total : 0,


### PR DESCRIPTION
## Problème

`GET /follow-app` renvoie une **erreur 500** lorsqu'un user n'a aucune app suivie.

## Cause

Quand un user suit puis retire des apps, une ligne `APP_LINKS` reste dans `USER_FOLLOWS_TABLE` (créée par `ensureLinksDoc`). Résultat : `items.length` vaut `1` même sans aucune app suivie, donc le garde existant (`if (!items.length)`) ne s'active pas.

Le code atteint alors `BatchGetCommand` avec un tableau `Keys` **vide**, que DynamoDB rejette (`ValidationException`) → 500.

À noter : le calcul `negative_rate` n'est **pas** en cause — il ne s'exécute que dans le `follows.map(...)`, jamais quand il n'y a aucune app suivie. Ce bug préexistait à cet ajout.

## Correctif

Ajout d'un garde après le filtrage des follows, cohérent avec celui déjà présent plus haut :

```js
const follows = items.filter(it => it.app_pk && it.app_pk !== "APP_LINKS");
if (!follows.length) return res.status(200).json({ followed: [] });
```

Le endpoint renvoie désormais `200 { followed: [] }` au lieu de crasher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)