### PR TITLE
perf(follow-app): précalculer negative_reviews au lieu de scanner à chaque requête

### DIFF
--- a/backend/followApp.js
+++ b/backend/followApp.js
@@ -18,7 +18,6 @@ const REGION = process.env.AWS_REGION;
 const USER_FOLLOWS_TABLE = process.env.USER_FOLLOWS_TABLE;
 const APPS_METADATA_TABLE = process.env.APPS_METADATA_TABLE;
 const APPS_INGEST_SCHEDULE_TABLE = process.env.APPS_INGEST_SCHEDULE_TABLE;
-const APP_REVIEWS_TABLE = process.env.APP_REVIEWS_TABLE;
 const DEFAULT_INTERVAL_MIN = Number.isFinite(parseInt(process.env.DEFAULT_INGEST_INTERVAL_MINUTES, 10))
   ? parseInt(process.env.DEFAULT_INGEST_INTERVAL_MINUTES, 10)
   : 60;
@@ -50,39 +49,11 @@ async function getAppName(appKey) {
   }
 }
 
-async function getNegativeRate(appKey) {
-  let lastKey;
-  let totalReviews = 0;
-  let negativeReviews = 0;
-
-  do {
-    const result = await ddb.send(new QueryCommand({
-      TableName: APP_REVIEWS_TABLE,
-      KeyConditionExpression: "app_pk = :app_pk",
-      ExpressionAttributeValues: {
-        ":app_pk": appKey
-      },
-      ProjectionExpression: "rating",
-      ExclusiveStartKey: lastKey
-    }));
-
-    const reviews = result.Items || [];
-
-    totalReviews += reviews.length;
-    negativeReviews += reviews.filter(
-      (review) => Number(review.rating) <= 3
-    ).length;
-
-    lastKey = result.LastEvaluatedKey;
-  } while (lastKey);
-
-  if (totalReviews === 0) {
-    return 0;
-  }
-
-  return Number(
-    ((negativeReviews / totalReviews) * 100).toFixed(2)
-  );
+// Taux de reviews négatives, dérivé des compteurs pré-agrégés
+// (total_reviews / negative_reviews) maintenus à l'ingestion. O(1), pas de query.
+function computeNegativeRate(total, negative) {
+  if (!total || total <= 0) return 0;
+  return Number(((negative / total) * 100).toFixed(2));
 }
 
 /* ===================== SCHEDULE ===================== */
@@ -425,12 +396,14 @@ export async function getFollowedApps(req, res) {
       RequestItems: {
         [APPS_METADATA_TABLE]: {
           Keys: keys,
-          ProjectionExpression: "app_pk, #c",
-          ExpressionAttributeNames: { "#c": "total_reviews" }
+          ProjectionExpression: "app_pk, #c, #n",
+          ExpressionAttributeNames: { "#c": "total_reviews", "#n": "negative_reviews" }
         }
       }
     }));
-    const totals = new Map((bg.Responses?.[APPS_METADATA_TABLE] || []).map(i => [i.app_pk, i["total_reviews"] || 0]));
+    const metaRows = bg.Responses?.[APPS_METADATA_TABLE] || [];
+    const totals = new Map(metaRows.map(i => [i.app_pk, i["total_reviews"] || 0]));
+    const negatives = new Map(metaRows.map(i => [i.app_pk, i["negative_reviews"] || 0]));
 
     const enriched = await Promise.all(follows.map(async (it) => {
       const appKey = it.app_pk;
@@ -455,7 +428,7 @@ export async function getFollowedApps(req, res) {
         } catch (e) {}
       }
 
-      const negativeRate = await getNegativeRate(appKey);
+      const negativeRate = computeNegativeRate(total, negatives.get(appKey) ?? 0);
 
       return {
         bundleId,

--- a/backend/ratings.js
+++ b/backend/ratings.js
@@ -1,0 +1,12 @@
+// ratings.js — Définition partagée de ce qui compte comme review "négative".
+// -------------------------------------------------------------------------
+// Cette définition DOIT rester identique entre l'ingestion (worker.js) et le
+// backfill (scripts/backfillNegativeReviews.js), sinon le compteur
+// negative_reviews diverge du stock réel des reviews.
+
+export const NEGATIVE_RATING_MAX = 3;
+
+export function isNegativeRating(rating) {
+  const r = Number(rating);
+  return Number.isFinite(r) && r <= NEGATIVE_RATING_MAX;
+}

--- a/backend/scripts/backfillNegativeReviews.js
+++ b/backend/scripts/backfillNegativeReviews.js
@@ -1,0 +1,137 @@
+// scripts/backfillNegativeReviews.js
+// ---------------------------------------------------------------------------
+// Backfill / réconciliation du compteur `negative_reviews` dans la table
+// metadata, à partir du STOCK réel des reviews.
+//
+// Pourquoi : `negative_reviews` est maintenu de façon incrémentale à
+// l'ingestion (worker.js), mais il part de 0 pour les apps dont les reviews
+// ont été ingérées avant l'ajout du compteur. Ce script recompte le vrai total
+// depuis APP_REVIEWS_TABLE et écrit la valeur via SET.
+//
+// Idempotent : recompte toujours depuis la source de vérité, donc ré-exécutable
+// sans risque de double comptage. À lancer de préférence dans une fenêtre calme
+// (une review ingérée pendant le scan d'une app peut être écrasée par le SET ;
+//  une nouvelle exécution corrige l'écart).
+//
+// Usage :
+//   AWS_REGION=eu-west-3 \
+//   APPS_METADATA_TABLE=... APP_REVIEWS_TABLE=... \
+//   node scripts/backfillNegativeReviews.js [--dry-run] [--app-pk=ios#123]
+// ---------------------------------------------------------------------------
+
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import {
+  DynamoDBDocumentClient,
+  QueryCommand,
+  ScanCommand,
+  UpdateCommand,
+} from "@aws-sdk/lib-dynamodb";
+
+import { NEGATIVE_RATING_MAX } from "../ratings.js";
+
+const REGION = process.env.AWS_REGION || "eu-west-3";
+const METADATA_TABLE = process.env.APPS_METADATA_TABLE;
+const REVIEWS_TABLE = process.env.APP_REVIEWS_TABLE;
+
+const args = process.argv.slice(2);
+const DRY_RUN = args.includes("--dry-run");
+const ONLY_APP_PK = args.find((a) => a.startsWith("--app-pk="))?.split("=")[1];
+
+if (!METADATA_TABLE || !REVIEWS_TABLE) {
+  console.error("APPS_METADATA_TABLE et APP_REVIEWS_TABLE sont requis.");
+  process.exit(1);
+}
+
+const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({ region: REGION }));
+
+// Compte les reviews négatives (rating <= NEGATIVE_RATING_MAX) d'une app.
+// Select: COUNT => on paie la lecture mais on ne rapatrie pas les items.
+async function countNegativeReviews(appPk) {
+  let count = 0;
+  let lastKey;
+
+  do {
+    const q = await ddb.send(
+      new QueryCommand({
+        TableName: REVIEWS_TABLE,
+        KeyConditionExpression: "app_pk = :pk",
+        FilterExpression: "#r <= :max",
+        ExpressionAttributeNames: { "#r": "rating" },
+        ExpressionAttributeValues: {
+          ":pk": appPk,
+          ":max": NEGATIVE_RATING_MAX,
+        },
+        Select: "COUNT",
+        ExclusiveStartKey: lastKey,
+      })
+    );
+
+    count += q.Count || 0;
+    lastKey = q.LastEvaluatedKey;
+  } while (lastKey);
+
+  return count;
+}
+
+async function* iterateAppPks() {
+  if (ONLY_APP_PK) {
+    yield ONLY_APP_PK;
+    return;
+  }
+
+  let lastKey;
+  do {
+    const out = await ddb.send(
+      new ScanCommand({
+        TableName: METADATA_TABLE,
+        ProjectionExpression: "app_pk",
+        ExclusiveStartKey: lastKey,
+      })
+    );
+
+    for (const item of out.Items || []) {
+      if (item.app_pk) yield item.app_pk;
+    }
+    lastKey = out.LastEvaluatedKey;
+  } while (lastKey);
+}
+
+async function run() {
+  let apps = 0;
+  let updated = 0;
+
+  for await (const appPk of iterateAppPks()) {
+    apps++;
+    try {
+      const negative = await countNegativeReviews(appPk);
+
+      if (DRY_RUN) {
+        console.log(`[DRY] ${appPk} negative_reviews=${negative}`);
+        continue;
+      }
+
+      await ddb.send(
+        new UpdateCommand({
+          TableName: METADATA_TABLE,
+          Key: { app_pk: appPk },
+          UpdateExpression: "SET negative_reviews = :n",
+          ExpressionAttributeValues: { ":n": negative },
+        })
+      );
+
+      updated++;
+      console.log(`[OK] ${appPk} negative_reviews=${negative}`);
+    } catch (e) {
+      console.error(`[ERR] ${appPk}:`, e?.message || e);
+    }
+  }
+
+  console.log(
+    `\nTerminé. Apps parcourues: ${apps}, mises à jour: ${updated}${DRY_RUN ? " (dry-run)" : ""}.`
+  );
+}
+
+run().catch((e) => {
+  console.error("Fatal:", e);
+  process.exit(1);
+});

--- a/backend/worker.js
+++ b/backend/worker.js
@@ -16,6 +16,7 @@ import gplay from "google-play-scraper";
 import store from "app-store-scraper";
 
 import { detectReviewAnomaly } from "./reviewAnomalyDetector.js";
+import { isNegativeRating } from "./ratings.js";
 
 // ---------- Config ----------
 
@@ -110,28 +111,32 @@ async function bumpAppReviewCounter({
   platform,
   bundleId,
   inserted,
+  negativeInserted = 0,
 }) {
   if (!inserted || inserted <= 0) return;
 
   const pk = appPk(platform, bundleId);
 
   try {
+    // ADD initialise l'attribut à 0 s'il est absent puis ajoute :neg (>= 0),
+    // donc pas besoin d'init explicite de negative_reviews.
     await ddbDoc.send(
       new UpdateCommand({
         TableName: METADATA_TABLE,
         Key: { app_pk: pk },
 
         UpdateExpression:
-          `ADD total_reviews :inc SET last_ingest_at = :now`,
+          `ADD total_reviews :inc, negative_reviews :neg SET last_ingest_at = :now`,
 
         ExpressionAttributeValues: {
           ":inc": inserted,
+          ":neg": negativeInserted,
           ":now": new Date().toISOString(),
         },
       })
     );
 
-    console.log(`[COUNTER] ${pk} += ${inserted}`);
+    console.log(`[COUNTER] ${pk} += ${inserted} (neg += ${negativeInserted})`);
   } catch (e) {
     console.error("[COUNTER] update error:", e?.message || e);
   }
@@ -558,10 +563,15 @@ async function runIncremental({ appName, platform, bundleId, backfillDays, gplay
     errors: ko,
   });
   
+  const negativeInserted = insertedReviews.filter((r) =>
+    isNegativeRating(r.rating)
+  ).length;
+
   return {
     fetched: fetched.length,
     sent: toInsert.length,
     inserted: ok,
+    negativeInserted,
     ddbDups: dup,
     errors: ko,
     alertsChecked: insertedReviews.length,
@@ -728,7 +738,12 @@ async function handler(event) {
         ...stats,
       });
 
-      await bumpAppReviewCounter({ platform, bundleId, inserted: stats.inserted });
+      await bumpAppReviewCounter({
+        platform,
+        bundleId,
+        inserted: stats.inserted,
+        negativeInserted: stats.negativeInserted,
+      });
       await ensureTotalInitialized({ platform, bundleId, inserted: stats.inserted });
     } catch (e) {
       console.error("Erreur worker:", e?.message || e);


### PR DESCRIPTION
## Problème

`GET /follow-app` calculait le `negative_rate` via `getNegativeRate`, qui faisait une **Query full-scan paginée sur toutes les reviews de chaque app suivie, à chaque requête** — O(nombre total de reviews) par app et par requête. Coûteux et lent dès qu'une app a beaucoup de reviews.

## Solution (Option A — compteur pré-agrégé)

On maintient un compteur `negative_reviews` dans la table metadata, exactement comme `total_reviews` l'est déjà à l'ingestion. Le taux est une simple division au read.

### Changements

- **`ratings.js`** (nouveau) — `NEGATIVE_RATING_MAX` / `isNegativeRating`, définition partagée du "négatif" (rating ≤ 3) pour garantir que l'ingestion et le backfill restent alignés.
- **`worker.js`** — compte les reviews nouvellement insérées avec `rating ≤ 3` et fait `ADD total_reviews :inc, negative_reviews :neg` dans le même `UpdateCommand`.
- **`followApp.js`** — suppression de `getNegativeRate` ; lecture de `negative_reviews` via le `BatchGetCommand` **déjà existant** et calcul du taux en mémoire → **zéro query supplémentaire**, O(1).
- **`scripts/backfillNegativeReviews.js`** (nouveau) — job one-shot idempotent qui recompte `negative_reviews` depuis la table de reviews pour le **stock** existant.

## Déploiement (ordre important)

1. Déployer worker + backend (l'incrément démarre pour les nouvelles reviews).
2. Lancer le backfill une fois, de préférence en fenêtre calme :
   ```
   node scripts/backfillNegativeReviews.js --dry-run   # vérif
   node scripts/backfillNegativeReviews.js             # écriture
   ```
3. Stock + flux cohérents à partir de là.

⚠️ Tant que le backfill n'est pas passé, les apps existantes affichent un `negative_rate` sous-estimé (compteur partant de 0). Attendu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)